### PR TITLE
Fixed compilation problems in mono.

### DIFF
--- a/src/Bottles.Console/Bottles.Console.csproj
+++ b/src/Bottles.Console/Bottles.Console.csproj
@@ -11,8 +11,6 @@
     <RootNamespace>Bottles.Console</RootNamespace>
     <AssemblyName>BottleRunner</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/src/Bottles.Host/Bottles.Host.csproj
+++ b/src/Bottles.Host/Bottles.Host.csproj
@@ -11,8 +11,6 @@
     <RootNamespace>Bottles.Host</RootNamespace>
     <AssemblyName>Bottles.Host</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
@@ -48,7 +46,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="Topshelf">
-      <HintPath>..\packages\Topshelf.2.2.2.0\lib\NET40\Topshelf.dll</HintPath>
+      <HintPath>..\packages\TopShelf.2.2.2.0\lib\NET40\Topshelf.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Bottles.sln
+++ b/src/Bottles.sln
@@ -109,6 +109,7 @@ Global
 		{665AEFFB-7582-484F-8C77-8310B1AE55F2}.Retail|Mixed Platforms.Build.0 = Release|Any CPU
 		{665AEFFB-7582-484F-8C77-8310B1AE55F2}.Retail|x86.ActiveCfg = Release|Any CPU
 		{0008611A-8192-4A00-B6A2-BD34E946C55D}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{0008611A-8192-4A00-B6A2-BD34E946C55D}.Debug|Any CPU.Build.0 = Debug|x86
 		{0008611A-8192-4A00-B6A2-BD34E946C55D}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
 		{0008611A-8192-4A00-B6A2-BD34E946C55D}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{0008611A-8192-4A00-B6A2-BD34E946C55D}.Debug|x86.ActiveCfg = Debug|x86
@@ -139,6 +140,7 @@ Global
 		{5692BDED-37BE-4686-89D8-E4A52DBDC1FB}.Retail|Mixed Platforms.Build.0 = Release|Any CPU
 		{5692BDED-37BE-4686-89D8-E4A52DBDC1FB}.Retail|x86.ActiveCfg = Release|Any CPU
 		{2B4DB712-DEB9-4EEC-B7AD-0CAE306AB042}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{2B4DB712-DEB9-4EEC-B7AD-0CAE306AB042}.Debug|Any CPU.Build.0 = Debug|x86
 		{2B4DB712-DEB9-4EEC-B7AD-0CAE306AB042}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
 		{2B4DB712-DEB9-4EEC-B7AD-0CAE306AB042}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{2B4DB712-DEB9-4EEC-B7AD-0CAE306AB042}.Debug|x86.ActiveCfg = Debug|x86


### PR DESCRIPTION
Subtle missing sln and proj settings cause bottles to fail to compile on mono (rake).
When opening the bottles solution in monodevelop, Bottles.Host and Bottles.Console projects were grayed out, "(not built in active configuration)".
