### PR TITLE
#52 Fixed double, nested "Config" folder for config bottles

### DIFF
--- a/src/Bottles.IntegrationTesting/BottleDomainProxy.cs
+++ b/src/Bottles.IntegrationTesting/BottleDomainProxy.cs
@@ -20,6 +20,11 @@ namespace Bottles.IntegrationTesting
             return readContent(path, BottleFiles.DataFolder);
         }
 
+        public string ReadConfig(string path)
+        {
+            return readContent(path, BottleFiles.ConfigFolder);
+        }
+
         public string ReadWebContent(string path)
         {
             return readContent(path, BottleFiles.WebContentFolder);

--- a/src/Bottles.IntegrationTesting/IntegrationTestContext.cs
+++ b/src/Bottles.IntegrationTesting/IntegrationTestContext.cs
@@ -61,16 +61,17 @@ assembly-pak -> Bundle up the content and data files for a self contained assemb
             }
         }
 
-
+        public static void CleanStagingDirectory()
+        {
+            var system = new FileSystem();
+            system.CleanDirectory(StagingDirectory);
+            Thread.Sleep(100);
+        }
 
         public static void ResetBottleProjectCode()
         {
             var system = new FileSystem();
-
-
-
-            system.CleanDirectory(StagingDirectory);
-            Thread.Sleep(100);
+            CleanStagingDirectory();
 
             system.Copy(SourceDirectory, StagingDirectory);
 
@@ -115,6 +116,12 @@ assembly-pak -> Bundle up the content and data files for a self contained assemb
             new FileSystem().WriteStringToFile(file, value);
         }
 
+        public static void SetConfig(string value)
+        {
+            var file = StagingDirectory.AppendPath("config").AppendPath("1.txt");
+            new FileSystem().WriteStringToFile(file, value);
+        }
+
         public static void SetContent(string value)
         {
             var file = StagingDirectory.AppendPath("content").
@@ -127,7 +134,6 @@ assembly-pak -> Bundle up the content and data files for a self contained assemb
             var processInfo = new ProcessStartInfo(BottleRunnerFile)
             {
                 Arguments = arguments,
-                CreateNoWindow = true,
                 WorkingDirectory = SolutionDirectory
             };
 

--- a/src/Bottles.IntegrationTesting/ProcessRunner.cs
+++ b/src/Bottles.IntegrationTesting/ProcessRunner.cs
@@ -19,7 +19,7 @@ namespace Bottles.IntegrationTesting
             info.WindowStyle = ProcessWindowStyle.Normal;
 
             //don't open a new terminal window
-            info.CreateNoWindow = false;
+            info.CreateNoWindow = true;
 
             info.RedirectStandardError = info.RedirectStandardOutput = true;
 

--- a/src/Bottles.IntegrationTesting/ZipPackageTesting.cs
+++ b/src/Bottles.IntegrationTesting/ZipPackageTesting.cs
@@ -29,6 +29,54 @@ namespace Bottles.IntegrationTesting
         }
 
         [Test]
+        public void config_bottle_should_have_proper_config_folder_in_zip()
+        {
+            CleanStagingDirectory();
+
+            RunBottlesCommand("init bottles-staging BottleProject");
+
+            AlterManifest(manifest =>
+            {
+                manifest.RemoveAllAssemblies();
+                manifest.SetRole("config");
+            });
+
+            SetConfig("some config stuff");
+
+            RunBottlesCommand("create bottles-staging -o zips/BottleProject.zip");
+
+            _domain.Proxy.LoadViaZip(ZipsDirectory);
+            
+            _domain.Proxy
+                .ReadConfig("1.txt").Trim()
+                .ShouldEqual("some config stuff");
+        }
+
+        [Test]
+        public void data_bottle_should_have_proper_data_folder_in_zip()
+        {
+            CleanStagingDirectory();
+
+            RunBottlesCommand("init bottles-staging BottleProject");
+
+            AlterManifest(manifest =>
+            {
+                manifest.RemoveAllAssemblies();
+                manifest.SetRole("data");
+            });
+
+            SetData("some data stuff");
+
+            RunBottlesCommand("create bottles-staging -o zips/BottleProject.zip");
+
+            _domain.Proxy.LoadViaZip(ZipsDirectory);
+
+            _domain.Proxy
+                .ReadData("1.txt").Trim()
+                .ShouldEqual("some data stuff");
+        }
+
+        [Test]
         public void bottle_should_be_reexploded_when_the_versioning_changes()
         {
             RunBottlesCommand("init bottles-staging BottleProject");

--- a/src/Bottles/Creation/ZipPackageCreator.cs
+++ b/src/Bottles/Creation/ZipPackageCreator.cs
@@ -117,11 +117,12 @@ namespace Bottles.Creation
         public void AddConfigFiles(CreateBottleInput input, IZipFile zipFile, PackageManifest manifest)
         {
             ConsoleWriter.Write("      Adding Config folder for " + BottleFiles.ConfigFiles);
-            zipFile.AddFiles(new ZipFolderRequest(){
-                FileSet = BottleFiles.ConfigFiles,
-                RootDirectory = input.PackageFolder,
-                ZipDirectory = BottleFiles.ConfigFolder
-            });
+            zipFile.AddFiles(new ZipFolderRequest()
+                            {
+                                FileSet = FileSet.Deep("*"),
+                                ZipDirectory = BottleFiles.ConfigFolder,
+                                RootDirectory = Path.Combine(input.PackageFolder, BottleFiles.ConfigFolder)
+                            });
         }
 
     }


### PR DESCRIPTION
Also added some tests for Config and Data role bottles to pin down how the zip file is created.

The underlying issue is describe in Issue #52 (basically, config bottle ZIP files were ending up with a nested config folder: ./Config/config/[files] and it should only be a single level ./Config/[files])
