### PR TITLE
Allow deployment in read only environment

### DIFF
--- a/src/AssemblyPackageEmpty/.package-manifest
+++ b/src/AssemblyPackageEmpty/.package-manifest
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Role>module</Role>
+  <Name>FakeProject</Name>
+  <assembly>AssemblyPackageEmpty</assembly>
+  <DataFileSet Include="data/*.*">
+    <DeepSearch>true</DeepSearch>
+  </DataFileSet>
+  <ContentFileSet Include="*.*" Exclude="data/*;*.cs;bin/*;obj/*;*.csproj*;packages.config;repositories.config;pak-*.zip">
+    <DeepSearch>true</DeepSearch>
+  </ContentFileSet>
+</package>

--- a/src/AssemblyPackageEmpty/AssemblyPackageEmpty.csproj
+++ b/src/AssemblyPackageEmpty/AssemblyPackageEmpty.csproj
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{DDB83364-7676-4B36-B223-BE6167CE551B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AssemblyPackageEmpty</RootNamespace>
+    <AssemblyName>AssemblyPackageEmpty</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="EmptyPackageMarker.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>
+    </PreBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <ItemGroup>
+    <EmbeddedResource Include=".package-manifest" />
+  </ItemGroup>
+</Project>

--- a/src/AssemblyPackageEmpty/EmptyPackageMarker.cs
+++ b/src/AssemblyPackageEmpty/EmptyPackageMarker.cs
@@ -1,0 +1,6 @@
+﻿namespace AssemblyPackageEmpty
+{
+    public class EmptyPackageMarker
+    {
+    }
+}

--- a/src/AssemblyPackageEmpty/Properties/AssemblyInfo.cs
+++ b/src/AssemblyPackageEmpty/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AssemblyPackageEmpty")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("AssemblyPackage")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2011")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9fea411f-7a5a-49bb-94f2-633acb58e74f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.2.3.4")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Bottles.Tests/Bottles.Tests.csproj
+++ b/src/Bottles.Tests/Bottles.Tests.csproj
@@ -138,6 +138,10 @@
     <Compile Include="Zipping\ZipFolderRequestTester.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\AssemblyPackageEmpty\AssemblyPackageEmpty.csproj">
+      <Project>{DDB83364-7676-4B36-B223-BE6167CE551B}</Project>
+      <Name>AssemblyPackageEmpty</Name>
+    </ProjectReference>
     <ProjectReference Include="..\AssemblyPackage\AssemblyPackage.csproj">
       <Project>{99DBA82A-E811-4DA0-983C-12E8317F8642}</Project>
       <Name>AssemblyPackage</Name>

--- a/src/Bottles.Tests/Exploding/BottleExploderTester.cs
+++ b/src/Bottles.Tests/Exploding/BottleExploderTester.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using AssemblyPackage;
+using AssemblyPackageEmpty;
 using Bottles.Diagnostics;
 using Bottles.Exploding;
 using Bottles.Zipping;
@@ -60,6 +61,31 @@ namespace Bottles.Tests.Exploding
         }
     }
 
+    [TestFixture]
+    public class integration_test_of_exploding_an_empty_assembly_package
+    {
+        private FileSystem fileSystem;
+
+        [SetUp]
+        public void SetUp()
+        {
+            fileSystem = new FileSystem();
+            fileSystem.DeleteDirectory("app1");
+            var exploder = new BottleExploder(new ZipFileService(fileSystem),
+                                               new BottleExploderLogger(s => ConsoleWriter.Write(s)), fileSystem);
+
+            var thePackage = new PackageInfo(new PackageManifest());
+
+            exploder.ExplodeAssembly("app1", typeof(EmptyPackageMarker).Assembly, thePackage);
+        }
+
+        [Test]
+        public void can_retrieve_the_version_from_the_package_folder()
+        {
+            var text = fileSystem.ReadStringFromFile("app1", "content", "AssemblyPackageEmpty", BottleFiles.VersionFile);
+            text.ShouldEqual("1.2.3.4");
+        }
+    }
 
     [TestFixture]
     public class when_extracting_package_zip_files : BottleExploderContext

--- a/src/Bottles.sln
+++ b/src/Bottles.sln
@@ -31,6 +31,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApplicationLoaderService", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApplicationSourceService", "ApplicationSourceService\ApplicationSourceService.csproj", "{09F7D616-4C29-4663-9131-DE11D4FFE9AB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyPackageEmpty", "AssemblyPackageEmpty\AssemblyPackageEmpty.csproj", "{DDB83364-7676-4B36-B223-BE6167CE551B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -255,6 +257,21 @@ Global
 		{09F7D616-4C29-4663-9131-DE11D4FFE9AB}.Retail|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{09F7D616-4C29-4663-9131-DE11D4FFE9AB}.Retail|Mixed Platforms.Build.0 = Release|Any CPU
 		{09F7D616-4C29-4663-9131-DE11D4FFE9AB}.Retail|x86.ActiveCfg = Release|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Release|x86.ActiveCfg = Release|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Retail|Any CPU.ActiveCfg = Release|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Retail|Any CPU.Build.0 = Release|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Retail|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Retail|Mixed Platforms.Build.0 = Release|Any CPU
+		{DDB83364-7676-4B36-B223-BE6167CE551B}.Retail|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -267,5 +284,6 @@ Global
 		{FE62CC8E-9566-4E6A-BE5E-F0A0D0530C39} = {703DCA45-AAA6-4E6C-BC08-61678551B57D}
 		{F19C5D9A-7C37-4862-A11B-15B70CA3BD6A} = {703DCA45-AAA6-4E6C-BC08-61678551B57D}
 		{09F7D616-4C29-4663-9131-DE11D4FFE9AB} = {703DCA45-AAA6-4E6C-BC08-61678551B57D}
+		{DDB83364-7676-4B36-B223-BE6167CE551B} = {703DCA45-AAA6-4E6C-BC08-61678551B57D}
 	EndGlobalSection
 EndGlobal

--- a/src/Bottles/Exploding/BottleExploder.cs
+++ b/src/Bottles/Exploding/BottleExploder.cs
@@ -132,6 +132,9 @@ namespace Bottles.Exploding
             _fileSystem.DeleteDirectory(directory);
             _fileSystem.CreateDirectory(directory);
 
+            var version = assembly.GetName().Version.ToString();
+            _fileSystem.WriteStringToFile(FileSystem.Combine(directory, BottleFiles.VersionFile), version);
+
             assembly.GetManifestResourceNames().Where(BottleFiles.IsEmbeddedPackageZipFile).Each(name =>
             {
                 var folderName = BottleFiles.EmbeddedPackageFolderName(name);
@@ -141,9 +144,6 @@ namespace Bottles.Exploding
                 var destinationFolder = FileSystem.Combine(directory, folderName);
 
                 _service.ExtractTo(description, stream, destinationFolder);
-
-                var version = assembly.GetName().Version.ToString();
-                _fileSystem.WriteStringToFile(FileSystem.Combine(directory, BottleFiles.VersionFile), version);
             });
         }
 


### PR DESCRIPTION
I've had a problem when deploying a fubu app which is running without write permissions.  I'm deploying the exploded bottle files, but it still tries to write to the file system.  

I've found that it's the empty package folders that are the problem.  Since they don't contain a .version file they're always considered out-of-date.  This pull request fixes that

This is my first pull request, so let me know if I've messed it up :)
