### PR TITLE
Add ability to list native assemblies in package manifest

### DIFF
--- a/src/Bottles/Creation/ZipPackageCreator.cs
+++ b/src/Bottles/Creation/ZipPackageCreator.cs
@@ -28,8 +28,8 @@ namespace Bottles.Creation
         public bool CreatePackage(CreateBottleInput input, PackageManifest manifest)
         {
             var binFolder = _fileSystem.FindBinaryDirectory(input.PackageFolder, input.TargetFlag);
+            var assemblies = _assemblyFinder.FindAssemblies(binFolder, manifest.AllAssemblies);
 
-            var assemblies = _assemblyFinder.FindAssemblies(binFolder, manifest.Assemblies);
             if (assemblies.Success)
             {
                 writeZipFile(input, manifest, assemblies);

--- a/src/Bottles/PackageInfo.cs
+++ b/src/Bottles/PackageInfo.cs
@@ -86,12 +86,12 @@ namespace Bottles
 
         public void RegisterAssemblyLocation(string assemblyName, string filePath)
         {
-            AddAssembly(new AssemblyTarget()
-                            {
-                                AssemblyName = assemblyName,
-                                FilePath = filePath
-                            });
-        }  
+            AddAssembly(new AssemblyTarget
+            {
+                AssemblyName = assemblyName,
+                FilePath = filePath
+            });
+        }
 
         public bool Equals(PackageInfo other)
         {
@@ -122,6 +122,8 @@ namespace Bottles
             description.Properties["Role"] = Role;
 
             description.Properties["Assemblies"] = Manifest.Assemblies.Join(", ");
+
+            if (Manifest.NativeAssemblies != null && Manifest.NativeAssemblies.Any()) description.Properties["NativeAssemblies"] = Manifest.NativeAssemblies.Join(", ");
 
             if (Manifest.BinPath != null) description.Properties["BinPath"] = Manifest.BinPath;
 

--- a/src/Bottles/PackageManifest.cs
+++ b/src/Bottles/PackageManifest.cs
@@ -1,22 +1,20 @@
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Xml.Serialization;
 using Bottles.Manifest;
 using FubuCore;
-using FubuCore.Descriptions;
 
 namespace Bottles
 {
     [XmlType("package")]
-    public class PackageManifest 
+    public class PackageManifest
     {
         public const string FILE = ".package-manifest";
 
         public static FileSet FileSetForSearching()
         {
-            return new FileSet(){
+            return new FileSet
+            {
                 DeepSearch = true,
                 Include = FILE
             };
@@ -44,16 +42,14 @@ namespace Bottles
         public string ManifestFileName { get; set; }
 
         private readonly IList<string> _assemblies = new List<string>();
-
-        
-
+        private readonly IList<string> _nativeAssemblies = new List<string>();
 
         public string Role { get; set; }
         public string Name { get; set; }
         public string BinPath { get; set; }
 
         [XmlElement("assembly")]
-        public string[] Assemblies 
+        public string[] Assemblies
         {
             get
             {
@@ -66,6 +62,27 @@ namespace Bottles
                 if (value == null) return;
                 _assemblies.AddRange(value);
             }
+        }
+
+        [XmlElement("nativeAssembly")]
+        public string[] NativeAssemblies
+        {
+            get
+            {
+                return _nativeAssemblies.ToArray();
+            }
+            set
+            {
+                _nativeAssemblies.Clear();
+
+                if (value == null) return;
+                _nativeAssemblies.AddRange(value);
+            }
+        }
+
+        public string[] AllAssemblies
+        {
+            get { return Assemblies.Union(NativeAssemblies).ToArray(); }
         }
 
         public bool AddAssembly(string assemblyName)
@@ -116,8 +133,6 @@ namespace Bottles
         {
             Role = role;
 
-
-
             switch (role)
             {
                 case BottleRoles.Config:
@@ -135,14 +150,13 @@ namespace Bottles
                     break;
 
                 default:
-                    ContentFileSet = new FileSet()
+                    ContentFileSet = new FileSet
                     {
                         DeepSearch = true,
                         Include = "*.*",
                         Exclude = "*.cs;bin/*;obj/*;*.csproj*;packages.config;repositories.config;pak-*.zip;*.sln"
                     };
                     break;
-
             }
         }
 
@@ -166,7 +180,8 @@ namespace Bottles
         public void AddDependency(string packageName, bool isMandatory)
         {
             _dependencies.RemoveAll(x => x.Name == packageName);
-            _dependencies.Add(new Dependency(){
+            _dependencies.Add(new Dependency
+            {
                 IsMandatory = isMandatory,
                 Name = packageName
             });


### PR DESCRIPTION
Native assemblies will be included in bin folder of generated zip
package, but not be loaded by Bottles in the exploded directory under
fubu-content.
