### PR TITLE
Minor steps towards working on mono

### DIFF
--- a/src/ApplicationLoaderService/ApplicationLoaderService.csproj
+++ b/src/ApplicationLoaderService/ApplicationLoaderService.csproj
@@ -31,10 +31,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FubuCore, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\FubuCore\lib\FubuCore.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -42,6 +38,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="FubuCore">
+      <HintPath>..\packages\FubuCore\lib\FubuCore.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MyApplicationLoader.cs" />

--- a/src/ApplicationSourceService/ApplicationSourceService.csproj
+++ b/src/ApplicationSourceService/ApplicationSourceService.csproj
@@ -31,10 +31,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FubuCore, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\FubuCore\lib\FubuCore.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -42,6 +38,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="FubuCore">
+      <HintPath>..\packages\FubuCore\lib\FubuCore.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Bottles.Tests/Harness/ServiceRunner.cs
+++ b/src/Bottles.Tests/Harness/ServiceRunner.cs
@@ -29,6 +29,9 @@ namespace Bottles.Tests.Harness
 
         public void Execute()
         {
+            var pf = System.Environment.OSVersion.Platform;
+            var isUnix = pf == PlatformID.Unix || pf == PlatformID.MacOSX;
+
             var processInfo = new ProcessStartInfo
             {
                 FileName = _directory.AppendPath("BottleServiceRunner.exe"),
@@ -39,6 +42,20 @@ namespace Bottles.Tests.Harness
                 //CreateNoWindow = true,
                 UseShellExecute = false
             };
+
+            if (isUnix) {
+                processInfo = new ProcessStartInfo
+                {
+                    FileName = "/usr/bin/mono",
+                    WorkingDirectory = _directory,
+                    Arguments = _directory.AppendPath("BottleServiceRunner.exe"),
+                    //RedirectStandardError = true,
+                    //RedirectStandardInput = true,
+                    //RedirectStandardOutput = true,
+                    //CreateNoWindow = true,
+                    UseShellExecute = false
+                };
+            }
 
             var process = Process.Start(processInfo);
             //Console.WriteLine(process.StandardOutput.ReadToEnd());

--- a/src/Bottles.Tests/Services/Integration/service_activation_integration_tester.cs
+++ b/src/Bottles.Tests/Services/Integration/service_activation_integration_tester.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 namespace Bottles.Tests.Services.Integration
 {
     [TestFixture, Explicit("These tests all require manual intervention to run")]
+    [Platform(Exclude = "Unix,Linux,MacOsX")]
     public class service_activation_integration_tester
     {
         /* NOTE:  You have to manually type CTRL-C into the window that pops up to complete


### PR DESCRIPTION
Nothing major here but have added support to ServiceRunner so that it will call mono instead of the exe directly and have also updated a couple of project files to remove the Version,Culture etc stuff for FubuCore.

This was to have something else,  but low and behold you had already done it :)

One of the big issues right now is that mono does not have a ServiceController implementation for *nix and therefore some unit tests are failing due to NotImplementedException being thrown by the BottleServiceRunner.

This is going to need to be resolved somehow.  probably not the easiest problem either.
