### PR TITLE
Use foreach instead of Extension method due to mono compiler bug.

### DIFF
--- a/src/Bottles/PackageFiles.cs
+++ b/src/Bottles/PackageFiles.cs
@@ -89,14 +89,17 @@ namespace Bottles
 
             if (!Directory.Exists(folderPath)) return false; //false because the path didn't even exist
 
-            Directory.GetFiles(folderPath, filePattern, SearchOption.AllDirectories).Each(fileName =>
+            // Use foreach as on mono you will get an internal compile error when using the standard
+            // string[].Each( fileName => { onFileCallback(....) }) pattern.
+            // https://bugzilla.xamarin.com/show_bug.cgi?id=16513
+            foreach(var fileName in Directory.GetFiles(folderPath, filePattern, SearchOption.AllDirectories))
             {
                 var name = fileName.PathRelativeTo(folderPath);
                 using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read))
                 {
                     onFileCallback(name, stream);
                 }
-            });
+            }
             return true;
 
         }


### PR DESCRIPTION
mono has a compiler bug which causes bottles to fail to compile.
This fixes the issue by using foreach instead of the IEnumerable Each extension method.

Bag to track upstream is here.
https://bugzilla.xamarin.com/show_bug.cgi?id=16513
