### PR TITLE
Filesystem case fix

### DIFF
--- a/src/Bottles.Tests/Services/Remote/RemoteDomainExpressionTester.cs
+++ b/src/Bottles.Tests/Services/Remote/RemoteDomainExpressionTester.cs
@@ -35,8 +35,8 @@ namespace Bottles.Services.Tests.Remote
 
             fileSystem.CreateDirectory("Service");
             fileSystem.CreateDirectory("Service", "bin");
-            fileSystem.CreateDirectory("Service", "bin", "release");
-            fileSystem.CreateDirectory("Service", "bin", "debug");
+            fileSystem.CreateDirectory("Service", "bin", "Release");
+            fileSystem.CreateDirectory("Service", "bin", "Debug");
 
             var expression = new RemoteDomainExpression();
             expression.Setup.PrivateBinPath.ShouldBeNull();


### PR DESCRIPTION
Just a simple fix by capitalising the Release and Debug directory names.
