### PR TITLE
Message history fix

### DIFF
--- a/src/Bottles.Docs/Bottles.Docs.csproj
+++ b/src/Bottles.Docs/Bottles.Docs.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -65,9 +65,5 @@
     <EmbeddedResource Include="pak-WebContent.zip" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="pak-Data.zip" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="pak-Config.zip" />
   </ItemGroup>
 </Project>

--- a/src/Bottles.Docs/snippets/Bottles.Tests/Services/Remote/BigRemoteServicesIntegrationTester.cs
+++ b/src/Bottles.Docs/snippets/Bottles.Tests/Services/Remote/BigRemoteServicesIntegrationTester.cs
@@ -208,6 +208,28 @@ namespace Bottles.Services.Tests.Remote
         }
 
         [Test]
+        public void coordinate_message_history_via_remote_service_and_clear_data_does_not_remove_listeners()
+        {
+
+            using (var runner = RemoteServiceRunner.For<SampleBootstrapper>())
+            {
+                runner.WaitForServiceToStart<SampleService.SampleService>();
+                runner.WaitForServiceToStart<SampleService.RemoteService>();
+
+                MessageHistory.StartListening(runner);
+                MessageHistory.ClearHistory();
+
+                var foo = new Foo();
+
+                EventAggregator.SentMessage(foo);
+
+
+                EventAggregator.Messaging.WaitForMessage<AllMessagesComplete>(() => runner.SendRemotely(foo))
+                                   .ShouldNotBeNull();
+            }
+        }
+
+        [Test]
         public void spin_up_the_remote_service_for_the_sample_and_send_messages_back_and_forth()
         {
             using (var runner = start())

--- a/src/Bottles.Tests/Services/Messaging/Tracking/MessageHistoryTester.cs
+++ b/src/Bottles.Tests/Services/Messaging/Tracking/MessageHistoryTester.cs
@@ -164,6 +164,28 @@ namespace Bottles.Services.Tests.Messaging.Tracking
             MessageHistory.Record(MessageTrack.ForReceived(foo3));
             assertAllCompleteMessage();
         }
+
+        [Test]
+        public void clear_history_removes_all()
+        {
+            var foo1 = new Foo();
+            var foo2 = new Foo();
+            var foo3 = new Foo();
+
+            MessageHistory.Record(MessageTrack.ForReceived(foo1));
+            MessageHistory.Record(MessageTrack.ForReceived(foo2));
+            MessageHistory.Record(MessageTrack.ForReceived(foo3));
+
+            MessageHistory.Record(MessageTrack.ForSent(foo1));
+            MessageHistory.Record(MessageTrack.ForSent(foo2));
+            MessageHistory.Record(MessageTrack.ForSent(foo3));
+
+            MessageHistory.ClearHistory();
+
+            MessageHistory.Outstanding().Any().ShouldBeFalse();
+            MessageHistory.Received().Any().ShouldBeFalse();
+            MessageHistory.All().Any().ShouldBeFalse();
+        }
     }
 
     public class Foo

--- a/src/Bottles.Tests/Services/Remote/BigRemoteServicesIntegrationTester.cs
+++ b/src/Bottles.Tests/Services/Remote/BigRemoteServicesIntegrationTester.cs
@@ -208,6 +208,28 @@ namespace Bottles.Services.Tests.Remote
         }
 
         [Test]
+        public void coordinate_message_history_via_remote_service_and_clear_data_does_not_remove_listeners()
+        {
+
+            using (var runner = RemoteServiceRunner.For<SampleBootstrapper>())
+            {
+                runner.WaitForServiceToStart<SampleService.SampleService>();
+                runner.WaitForServiceToStart<SampleService.RemoteService>();
+
+                MessageHistory.StartListening(runner);
+                MessageHistory.ClearHistory();
+
+                var foo = new Foo();
+
+                EventAggregator.SentMessage(foo);
+
+
+                EventAggregator.Messaging.WaitForMessage<AllMessagesComplete>(() => runner.SendRemotely(foo))
+                                   .ShouldNotBeNull();
+            }
+        }
+
+        [Test]
         public void spin_up_the_remote_service_for_the_sample_and_send_messages_back_and_forth()
         {
             using (var runner = start())

--- a/src/Bottles/Services/Messaging/Tracking/MessageHistory.cs
+++ b/src/Bottles/Services/Messaging/Tracking/MessageHistory.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Bottles.Services.Remote;
@@ -23,7 +22,6 @@ namespace Bottles.Services.Messaging.Tracking
         {
             ClearAll();
 
-            _hubs.Clear();
             _hubs.AddRange(runners.Select(x => x.Messaging));
             _hubs.Add(EventAggregator.Messaging);
             _listener = new MessageTrackListener();
@@ -33,7 +31,7 @@ namespace Bottles.Services.Messaging.Tracking
 
         public static void ClearAll()
         {
-            clearData();
+            ClearHistory();
 
             if (_listener != null)
             {
@@ -44,7 +42,7 @@ namespace Bottles.Services.Messaging.Tracking
             _hubs.Clear();
         }
 
-        private static void clearData()
+        public static void ClearHistory()
         {
             _lock.Write(() => {
                 _sent.Clear();
@@ -108,7 +106,7 @@ namespace Bottles.Services.Messaging.Tracking
 
         public static bool WaitForWorkToFinish(Action action, int timeoutMilliseconds = 5000)
         {
-            clearData();
+            ClearHistory();
             action();
             return Wait.Until(() => !Outstanding().Any() && All().Any(), timeoutInMilliseconds: timeoutMilliseconds);
         }


### PR DESCRIPTION
 Expose way to clear history from MessageHistory

```
* We don't necessarily want to always call ClearAll when using
  MessageHistory since it also removes the MessageTrackListener from
  each of the IMessagingHubs.
* Expose ClearHistory (previously a private method called clearData)
```

@jeremydmiller I've got some tests around this, but are there any other tests you can think of that I should write for this?
