### PR TITLE
Changed BottleServiceRunner project build configuration to be Any CPU

### DIFF
--- a/src/BottleServiceRunner/BottleServiceRunner.csproj
+++ b/src/BottleServiceRunner/BottleServiceRunner.csproj
@@ -34,6 +34,24 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="FubuCore">
       <HintPath>..\packages\FubuCore\lib\FubuCore.dll</HintPath>

--- a/src/Bottles.sln
+++ b/src/Bottles.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyPackage", "AssemblyPackage\AssemblyPackage.csproj", "{99DBA82A-E811-4DA0-983C-12E8317F8642}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bottles", "Bottles\Bottles.csproj", "{E208A2B1-31B0-4455-BA16-3D79F5887ECE}"
@@ -172,13 +174,13 @@ Global
 		{0637CB99-A3F4-4F51-AFA9-1B5B074DD7A8}.Retail|Mixed Platforms.Build.0 = Release|Any CPU
 		{0637CB99-A3F4-4F51-AFA9-1B5B074DD7A8}.Retail|x86.ActiveCfg = Release|Any CPU
 		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Debug|x86.ActiveCfg = Debug|x86
 		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Debug|x86.Build.0 = Debug|x86
 		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Release|Any CPU.ActiveCfg = Release|x86
-		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Release|Mixed Platforms.ActiveCfg = Release|x86
-		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Release|Mixed Platforms.Build.0 = Release|x86
+		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Release|x86.ActiveCfg = Release|x86
 		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Release|x86.Build.0 = Release|x86
 		{98E3001B-02B2-4449-927D-F5D63C3C5AA9}.Retail|Any CPU.ActiveCfg = Release|x86


### PR DESCRIPTION
I ran this locally with a project that uses FubuTransportation and it worked fine.  At this point I don't think we'll need separate nugets for 32 and 64 bit, so I just changed the default build configuration.
